### PR TITLE
feat: Implement Hasher trait for TentHasher

### DIFF
--- a/tenthash-rust/tests/test_vectors.rs
+++ b/tenthash-rust/tests/test_vectors.rs
@@ -75,3 +75,61 @@ fn streaming_multi_chunk() {
         }
     }
 }
+
+#[test]
+fn test_hasher_trait() {
+    use core::hash::Hasher;
+
+    for (data, _) in TEST_VECTORS.iter() {
+        let mut hasher1 = TentHasher::new();
+        hasher1.write(data);
+        let hash1 = hasher1.finish();
+
+        let mut hasher2 = TentHasher::new();
+        hasher2.write(data);
+        let hash2 = hasher2.finish();
+
+        assert_eq!(hash1, hash2, "Hasher should produce consistent results");
+    }
+}
+
+#[test]
+fn test_build_hasher() {
+    use core::hash::{BuildHasher, Hasher};
+    let builder = tenthash::TentHashBuilder;
+
+    for (data, _) in TEST_VECTORS.iter() {
+        let mut hasher1 = builder.build_hasher();
+        let mut hasher2 = builder.build_hasher();
+
+        hasher1.write(data);
+        hasher2.write(data);
+
+        assert_eq!(hasher1.finish(), hasher2.finish(),
+            "BuildHasher should create consistent hashers");
+    }
+}
+
+#[test]
+fn test_hasher_write_chunks() {
+    use core::hash::Hasher;
+
+    for (data, _) in TEST_VECTORS.iter() {
+        let mut hasher1 = TentHasher::new();
+        hasher1.write(data);
+        let hash1 = hasher1.finish();
+
+        let mut hasher2 = TentHasher::new();
+        if !data.is_empty() {
+            let mid = (data.len() + 1) / 2;
+            hasher2.write(&data[..mid]);
+            hasher2.write(&data[mid..]);
+        } else {
+            hasher2.write(data);
+        }
+        let hash2 = hasher2.finish();
+
+        assert_eq!(hash1, hash2,
+            "Hash should be independent of how data is chunked");
+    }
+}


### PR DESCRIPTION
Really interesting project! Minor improvement idea, so that the hash function could be used more widely.

Implements [the `Hasher` trait](https://doc.rust-lang.org/std/hash/trait.Hasher.html) from `core::hash` for TentHasher, enabling its use as a general-purpose hasher.

- Added `Hasher` trait implementation from `core::hash` as `TentHasher`
- Added `BuildHasher` trait implementation from `core::hash` as `TentHashBuilder`

The `Hasher` trait in Rust requires a `finish()` method that returns a `u64` (8 bytes). While TentHash produces a 20-byte hash, we use the first 8 bytes when implementing the `Hasher` trait. This is used by collections like `HashMap` when they need a fixed-size hash value.

To use TentHash with collections, you need both the hasher and its builder:
- `TentHasher` implements the actual hashing
- `TentHashBuilder` allows collections to create new hashers as needed

## Example

With this PR, you can use TentHash to initialise HashMap's and HashSet's from the standard library, or with `hashbrown::HashMap` in no_std environments.

```rust
    // Using with HashMap
    let mut map: HashMap<String, i32, TentHashBuilder> = HashMap::with_hasher(TentHashBuilder);
    map.insert("key1".to_string(), 42);
    map.insert("key2".to_string(), 123);
    println!("HashMap value: {:?}", map.get("key1"));

    // Using with HashSet
    let mut set: HashSet<String, TentHashBuilder> = HashSet::with_hasher(TentHashBuilder);
    set.insert("unique1".to_string());
    set.insert("unique2".to_string());
    set.insert("unique1".to_string()); // Duplicate won't be added
    println!("HashSet size: {}", set.len());
    println!("Contains 'unique1': {}", set.contains("unique1"));
```

## Testing

All existing tests pass. I added some more tests to cover the new changes introduces in this PR. 

The hasher maintains `no_std` compatibility.