### PR TITLE
TentHash Rust: Add 16 byte and 128bit conversions in `DigestExt` trait

### DIFF
--- a/tenthash-rust/src/lib.rs
+++ b/tenthash-rust/src/lib.rs
@@ -215,3 +215,33 @@ fn mix_state(state: &mut [u64; 4]) {
         state.swap(0, 1);
     }
 }
+
+/// A helper trait we implement for the digest type, `[u8; 20]`.
+pub trait DigestExt {
+    /// Truncate the 20-byte digest to 16 bytes.
+    fn to_16_bytes(self) -> [u8; 16];
+
+    /// Truncate the 160-bit digest to the first 128 bits as a [`u128`].
+    fn to_u128(self) -> u128;
+}
+
+impl DigestExt for [u8; 20] {
+    #[inline(always)]
+    fn to_16_bytes(self) -> [u8; 16] {
+        let self_ref: &[u8; 20] = &self;
+        // SAFETY:
+        // - both are plain data types
+        // - all bytes initialized
+        // - same alignment
+        // - resulting array ref is within bounds of the source object
+        let byte_16_ref: &[u8; 16] = unsafe {
+            &*((self_ref as *const [u8; 20]).cast::<[u8; 16]>())
+        };
+        *byte_16_ref
+    }
+
+    #[inline(always)]
+    fn to_u128(self) -> u128 {
+        u128::from_le_bytes(self.to_16_bytes())
+    }
+}

--- a/tenthash-rust/tests/test_vectors.rs
+++ b/tenthash-rust/tests/test_vectors.rs
@@ -1,3 +1,4 @@
+use tenthash::DigestExt;
 use tenthash::TentHash;
 
 const TEST_VECTORS: &[(&[u8], &str)] = &[
@@ -73,5 +74,18 @@ fn streaming_multi_chunk() {
                 assert_eq!(digest_to_string(&hasher.finalize()), digest);
             }
         }
+    }
+}
+
+#[test]
+fn full_vs_128_digest() {
+    for (data, _) in TEST_VECTORS.iter().copied() {
+        let digest = tenthash::hash(data);
+        let hash_16_indexed = digest[0..16].try_into().unwrap();
+        let hash_16_trait = digest.to_16_bytes();
+        let hash_128_from_le_bytes = u128::from_le_bytes(hash_16_indexed);
+        let hash_128_trait = digest.to_u128();
+        assert_eq!(hash_16_indexed, hash_16_trait);
+        assert_eq!(hash_128_from_le_bytes, hash_128_trait);
     }
 }


### PR DESCRIPTION
Implements #4